### PR TITLE
Introduce block registry for extensible block types

### DIFF
--- a/src/BlockRegistry.cpp
+++ b/src/BlockRegistry.cpp
@@ -1,0 +1,17 @@
+#include "BlockRegistry.h"
+
+std::vector<BlockType> BlockRegistry::blocks;
+
+BlockRegistry::BlockID BlockRegistry::registerBlock(const std::string& name, bool opaque) {
+    BlockID id = static_cast<BlockID>(blocks.size());
+    blocks.push_back({name, opaque});
+    return id;
+}
+
+const BlockType& BlockRegistry::get(BlockID id) {
+    return blocks.at(id);
+}
+
+size_t BlockRegistry::count() {
+    return blocks.size();
+}

--- a/src/BlockRegistry.h
+++ b/src/BlockRegistry.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <cstdint>
+
+struct BlockType {
+    std::string name;
+    bool opaque;
+};
+
+class BlockRegistry {
+public:
+    using BlockID = uint8_t;
+    static BlockID registerBlock(const std::string& name, bool opaque);
+    static const BlockType& get(BlockID id);
+    static size_t count();
+private:
+    static std::vector<BlockType> blocks;
+};

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <array>
-#include <cstdint>
+#include "BlockRegistry.h"
 
 struct Voxel {
-    uint8_t type = 0; // 0 == air
+    BlockRegistry::BlockID type = 0; // 0 == air
 };
 
 class Chunk {

--- a/src/PixelGame.cpp
+++ b/src/PixelGame.cpp
@@ -1,7 +1,13 @@
 #include "PixelGame.h"
+#include "BlockRegistry.h"
 #include <iostream>
 
-PixelGame::PixelGame() : pool(std::thread::hardware_concurrency()) {}
+PixelGame::PixelGame() : pool(std::thread::hardware_concurrency()) {
+    if (BlockRegistry::count() == 0) {
+        BlockRegistry::registerBlock("Air", false);   // id 0
+        BlockRegistry::registerBlock("Dirt", true);   // id 1
+    }
+}
 PixelGame::~PixelGame() {}
 
 void PixelGame::loadWorld(std::vector<Vertex>& vertices,


### PR DESCRIPTION
## Summary
- create `BlockRegistry` class for registering block types
- use `BlockID` in `Voxel` struct
- register default `Air` and `Dirt` blocks when the game starts

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68827c2819ec8329aec40c80bc06eb82